### PR TITLE
feature: 경고 모달 구현

### DIFF
--- a/src/components/Common/Navbar/AlarmButton.tsx
+++ b/src/components/Common/Navbar/AlarmButton.tsx
@@ -1,12 +1,28 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import * as S from "./HeaderButtonStyle";
 import bell from "../../../../public/assets/common/navbar/bell.svg";
 import AlarmModal from "../../Modal/AlarmModal";
+import LoginRequiredModal from "../../Modal/LoginRequiredModal";
+import { useAuth } from "../../../hooks/common/useAuth";
+import UserModal from "../../Modal/Auth/UserModal";
 
 const AlarmButton: React.FC = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isUserModalOpen, setIsUserModalOpen] = useState(false);
+  const {isAuthenticated}= useAuth();
 
+  const accessToken = isAuthenticated ? localStorage.getItem("accessToken") : null;
+  const refreshToken = isAuthenticated ? localStorage.getItem("refreshToken") : null;
+
+  const openUserModal = () => {
+    setIsUserModalOpen(true);
+  };
+
+  const closeUserModal = () => {
+    setIsUserModalOpen(false);
+  };
+  
   const openModal = () => {
     setIsModalOpen(true);
   };
@@ -14,12 +30,27 @@ const AlarmButton: React.FC = () => {
     setIsModalOpen(false);
   };
 
+  useEffect(()=>{
+    if(isModalOpen && !isAuthenticated){
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "auto"; 
+    }
+    return () => {
+      document.body.style.overflow = "auto";
+    };
+  },[isModalOpen]);
+
   return (
     <>
       <StyledHeaderButton onClick={openModal}>
         <S.Icon src={bell} />
       </StyledHeaderButton>
-      {isModalOpen && <AlarmModal closeModal={closeModal} />}
+      {isModalOpen && 
+      (isAuthenticated
+      ? <AlarmModal closeModal={closeModal} />
+      : <LoginRequiredModal onClose={closeModal} isReqLogin={true} toLogin={openUserModal}/>)}
+      {isUserModalOpen && <UserModal closeModal={()=>closeUserModal()}></UserModal>}
     </>
   );
 };

--- a/src/components/Layout/Navbar.tsx
+++ b/src/components/Layout/Navbar.tsx
@@ -9,6 +9,7 @@ import Overlay from "../Common/Overlay";
 import AlarmModal from "../Modal/AlarmModal";
 import UserModal from "../Modal/Auth/UserModal";
 import GreetingModal from "../Modal/GreetingModal";
+import LoginRequiredModal from "../Modal/LoginRequiredModal";
 
 const Navbar: React.FC = () => {
   const [isCompact, setIsCompact] = useState(window.innerWidth <= 1234);
@@ -74,7 +75,9 @@ const Navbar: React.FC = () => {
           setIsAlarmOpen={setIsAlarmOpen}
           setIsUserModalOpen={handleOpenUserModal}/>
       )}
-      {isAlarmOpen && <AlarmModal closeModal={() => setIsAlarmOpen(false)} />}
+      {isAlarmOpen && isLoggedIn && <AlarmModal closeModal={() => setIsAlarmOpen(false)} />}
+      {isAlarmOpen && !isLoggedIn && <LoginRequiredModal/>}
+      
       {isUserModalOpen && !isLoggedIn && <UserModal closeModal={() => setIsUserModalOpen(false)} onLogin={handleLogin} />}
       {isUserModalOpen && isLoggedIn && <GreetingModal onLogout={handleLogout} closeModal={() => setIsUserModalOpen(false)} />}
     </Nav>

--- a/src/components/Modal/GreetingModal.tsx
+++ b/src/components/Modal/GreetingModal.tsx
@@ -18,11 +18,11 @@ const GreetingModal: React.FC<GreetingModalProps> = ({ closeModal }) => {
     };
   }, [closeModal]);
 
-  useEffect(() => {
-    if (!isAuthenticated) {
-      closeModal();
-    }
-  }, [isAuthenticated, closeModal]);
+  // useEffect(() => {
+  //   if (!isAuthenticated) {
+  //     closeModal();
+  //   }
+  // }, [isAuthenticated, closeModal]);
 
   const handleLogout = () => {
     logout();

--- a/src/components/Modal/LoginRequiredModal.tsx
+++ b/src/components/Modal/LoginRequiredModal.tsx
@@ -1,0 +1,92 @@
+import styled from "styled-components";
+import * as S from "./../../styles/Typography.ts";
+import { useState } from "react";
+type LoginRequiredModalProps = {
+  isReqLogin: boolean;
+  onClose: () => void;
+  toLogin: () => void;
+}
+
+const LoginRequiredModal : React.FC<LoginRequiredModalProps> = ({isReqLogin, onClose, toLogin}) => {
+
+  
+  return(
+    <Overlay>
+      <ModalContent>
+        <S.BodyTypo>{isReqLogin ? "로그인 후 이용 가능한 기능입니다." :
+          "잘못된 접근입니다"}</S.BodyTypo>
+        <ButtonContainer>
+        {isReqLogin && 
+          <GoLoginButton>
+            <S.CaptionTypoMedium onClick={()=>{
+              toLogin();
+              onClose();
+            }}>로그인 하러 가기</S.CaptionTypoMedium>
+          </GoLoginButton>}
+          <CloseButton onClick={()=>onClose()}>
+            <S.CaptionTypoMedium>닫기</S.CaptionTypoMedium>
+          </CloseButton>
+        </ButtonContainer>
+      </ModalContent>
+    </Overlay>
+  )
+};
+
+export default LoginRequiredModal;
+
+const Overlay = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  display: flex; 
+  background-color: rgba(30, 30, 32, 0.8);
+  justify-content: center;
+  align-items: center;
+  z-index: 10;
+`;
+
+const ModalContent = styled.div`
+  display : flex;
+  width: 23.625rem;
+  padding: 2.563rem 1.938rem 1.75rem 1.938rem;
+  margin-bottom: 70vh;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.688rem;
+  border-radius: 1.25rem;
+  background: var(--grey-80, rgba(38, 38, 43, 0.80));
+
+  /* modal */
+  box-shadow: 0px 0px 1.875rem 0px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(1.563rem);
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  gap : 0.813rem;
+  justify-content: flex-end;
+  width: 100%;
+`;
+
+const Button = styled.button`
+  display: flex;
+  padding: 0.625rem 1.563rem;
+  justify-content: center;
+  align-items: center;
+  gap: 0.625rem;
+  border-radius: 0.625rem;
+  background: var(--grey-100, #26262A);
+  cursor: pointer;
+`;
+
+const GoLoginButton = styled(Button)`
+  border: 1.5px solid var(--primary-purple, #7061F0);
+  color : var(--primary-purple, #7061F0);
+`;
+
+const CloseButton = styled(Button)`
+  border: 1.5px solid var(--White-50, rgba(255, 255, 255, 0.50));
+  color: var(--white-50,rgba(255, 255, 255, 0.50));
+`;


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가 (Feat)
- [ ] 버그 / 에러 수정 (Fix)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] 코드 구조 등 리팩토링 (Refactor)
- [ ] 스타일 추가 및 수정 (Style)
- [ ] 문서 관련 (Docs)
- [ ] 기능 삭제 (Delete)


## 📝작업 내용
로그인이 필요한 기능이나 구현이 안된 기능 클릭 시 나오는 경고 모달창을 구현했습니다.

"로그인 하러가기" 가 페이지가 아니고 모달이라 사용법이 좀 복잡할 수 있습니다 .. 보시고 다른 괜찮은 구현 방법 있으면 아이디어 부탁드립니다.

`LoginRequiredModal.tsx`
로그인이 요구되는 페이지, 기능에 들어가기 전 로그인 확인 후 안되어있으면 해당 모달창이 나오도록 하면 됩니다. props는 아래와 같습니다.
- `isReqLogin (boolean)` : true - "로그인 후 이용 가능한 기능입니다" + 로그인 하러 가기 버튼 / false - "잘못된 접근입니다" + 닫기 버튼
- `onClose (함수)` : 상위 컴포넌트에서 경고 모달창 open/close 상태를 만들어두고, close로 상태변경하는 함수를 만들어 전달하면 됩니다.
- `toLogin (함수)` : 상위 컴포넌트에 유저 모달창(로그인 모달) open/close 상태를 만들어두고, open상태로 변경하는 함수를 만들어 전달하면 됩니다.

경고 모달창이 떠있을 때 스크롤이 못 움직이게 하기 위해서, 경고모달을 불러오는 상위 컴포넌트에 다음 코드를 넣어주면 됩니다.
```javascript
useEffect(()=>{
    if(isModalOpen && !isAuthenticated){
      document.body.style.overflow = "hidden";
    } else {
      document.body.style.overflow = "auto"; 
    }
    return () => {
      document.body.style.overflow = "auto";
    };
  },[isModalOpen]);
```

로그인 상태는 useAuth 훅에서 isAuthenticated 상태를 가져왔습니다 !


## 스크린샷(선택)
`isReqLogin={true}`

https://github.com/user-attachments/assets/d690e38f-f781-4819-b30e-c43b92914b2b



`isReqLogin={false}`


https://github.com/user-attachments/assets/f6b33d92-359f-4a51-8f8c-d41037ccd4a8


## 💬리뷰 요구사항 / 질문(선택)
버그 있으면 언제든 말씀해주세요

## TO-DO(선택)
- [ ] _To Do를 작성해 주세요_
