### PR TITLE
feat: 로고 클릭 시 랜딩 페이지 이동 & 모바일 화면에서 검색창 활성화

### DIFF
--- a/src/components/Common/Navbar/SearchBar.tsx
+++ b/src/components/Common/Navbar/SearchBar.tsx
@@ -3,35 +3,45 @@ import styled from "styled-components";
 import * as S from "../../../styles/Typography";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import Overlay from "../Overlay";
 
 const SearchBar: React.FC = () => {
   const [focus, setFocus] = useState(false);
   const [keyword, setKeyword] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
   const navigate = useNavigate();
 
   const handleFocus = () => {
     setFocus(true);
-  }
+  };
 
   const handleBlur = () => {
     setFocus(false);
-  }
+  };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setKeyword(e.target.value);
-  }
+  };
 
   const handleSubmit = (e: any) => {
     e.preventDefault();
     if (keyword.trim() === "") return;
-    navigate('/SearchResults', {
+    navigate("/SearchResults", {
       replace: false,
       state: { keyword: keyword }
     });
-  }
+    setIsOpen(false);
+  };
+
+  const handleOverlayClick = (e?: React.MouseEvent) => {
+    if (!e || e.target === e.currentTarget) {
+      setIsOpen(false);
+    }
+  };
 
   return (
     <>
+    {/*PC용 검색창*/}
     <SearchBarWrapper $isFocused={focus} onSubmit={handleSubmit}>
       <img src="/assets/SearchResults/search-magnifier.svg" alt="search icon" />
       <SearchInput
@@ -42,16 +52,54 @@ const SearchBar: React.FC = () => {
         onChange={handleChange}
       />
     </SearchBarWrapper>
-    <SmallSearchIcon src="../../../../public/assets/common/navbar/Search small button.svg" alt="small search icon" />
+
+    {/*모바일용 검색 아이콘*/}
+    <SmallSearchIcon 
+      src="../../../../public/assets/common/navbar/Search small button.svg" 
+      alt="small search icon"
+      onClick={() => setIsOpen(true)}/>
+    {/*모바일용 검색창*/}
+    {isOpen && (
+      <>
+      <Overlay onClick={handleOverlayClick} />
+        <MobileSearchWrapper $isFocused={focus} onSubmit={handleSubmit} onClick={(e) => e.stopPropagation()}>
+          <img src="/assets/SearchResults/search-magnifier.svg" alt="search icon" />
+          <SearchInput
+            placeholder="검색어를 입력하세요..."
+            value={keyword}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            onChange={handleChange}
+          />
+        </MobileSearchWrapper>
+      </>)}
     </>
-  )
-};
+);};
 
 export default SearchBar;
 
 interface SearchBarWrapperProps {
   $isFocused: boolean;
 }
+
+const MobileSearchWrapper = styled.form<SearchBarWrapperProps>`
+  position: fixed;
+  top: 4%;
+  left: 50%;
+  transform: translateX(-50%);
+
+  box-sizing: border-box;
+  width: 350px;
+  height: 2.563rem;
+  padding: 3px 3px 3px 23px;
+  border-radius: 50px;
+  border: 1px solid var(--White-100, #FFF);
+  background: var(--background-black, #161616);
+
+  display: flex;
+  align-items: center;
+  z-index: 1000;
+`;
 
 const SearchBarWrapper = styled.form<SearchBarWrapperProps>`
   box-sizing: border-box;
@@ -62,8 +110,8 @@ const SearchBarWrapper = styled.form<SearchBarWrapperProps>`
   align-items: center;
   border-radius: 50px;
   border: ${(props) => props.$isFocused ?
-    `1px solid var(--White-100, #FFF);` :
-    `1px solid var(--White-10, rgba(255, 255, 255, 0.1))`
+    "1px solid var(--White-100, #FFF);" :
+    "1px solid var(--White-10, rgba(255, 255, 255, 0.1))"
   };
   background: var(--background-black, #161616);
 

--- a/src/components/Layout/Navbar.tsx
+++ b/src/components/Layout/Navbar.tsx
@@ -8,7 +8,7 @@ import SidebarContent from "./SidebarContent";
 import Overlay from "../Common/Overlay";
 import AlarmModal from "../Modal/AlarmModal";
 import UserModal from "../Modal/Auth/UserModal";
-import GreetingModal from "../Modal/GreetingModal";
+import { NavLink } from "react-router-dom";
 
 const Navbar: React.FC = () => {
   const [isCompact, setIsCompact] = useState(window.innerWidth <= 1234);
@@ -16,7 +16,6 @@ const Navbar: React.FC = () => {
   const [isAlarmOpen, setIsAlarmOpen] = useState(false);
 
   const [isUserModalOpen, setIsUserModalOpen] = useState(false);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
 
   // 사이드바가 열리면 스크롤이 비활성화
   useEffect(() => {
@@ -40,20 +39,14 @@ const Navbar: React.FC = () => {
     setIsUserModalOpen(true);
     setIsSidebarOpen(false);
   };
-  // 로그인 여부 확인
-  const handleLogin = () =>  {
-    setIsLoggedIn(true);
-    setIsUserModalOpen(false);
-  };
-  const handleLogout = () => {
-    setIsLoggedIn(false);
-    setIsUserModalOpen(false);
-  };
 
   return (
     <Nav>
       <NavLeft>
-        <Logo><LogoImg src="../../../public/assets/common/navbar/memesphere main logo.svg" />MemeSphere</Logo>
+        <Logo to="/">
+            <LogoImg src="../../../public/assets/common/navbar/memesphere main logo.svg" />
+            <LogoTypo>MemeSphere</LogoTypo>
+        </Logo>
         {!isCompact && <NavLeftPageWrapper><NavLeftPage /></NavLeftPageWrapper>}
       </NavLeft>
 
@@ -75,8 +68,7 @@ const Navbar: React.FC = () => {
           setIsUserModalOpen={handleOpenUserModal}/>
       )}
       {isAlarmOpen && <AlarmModal closeModal={() => setIsAlarmOpen(false)} />}
-      {isUserModalOpen && !isLoggedIn && <UserModal closeModal={() => setIsUserModalOpen(false)} onLogin={handleLogin} />}
-      {isUserModalOpen && isLoggedIn && <GreetingModal onLogout={handleLogout} closeModal={() => setIsUserModalOpen(false)} />}
+      {isUserModalOpen && <UserModal closeModal={() => setIsUserModalOpen(false)} />}
     </Nav>
   );
 };
@@ -86,14 +78,18 @@ export default Navbar;
 const MenuIcon = styled.img`
   width: 2.563rem;
 `;
-
+const Logo = styled(NavLink)`
+  text-decoration: none;
+  display: flex;
+  margin-left: 4.306vw;
+`;
 const LogoImg = styled.img`
   width: 1.813rem;
   margin-right: 0.188rem;
 `;
 
-const Logo = styled(TitleTypo)`
-  margin-left: 4.306vw;
+const LogoTypo = styled(TitleTypo)`
+  
   color: var(--white-100);
   display: flex;
 `;


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [X] 기능 추가 (Feat)

## 📝작업 내용
- 로고 클릭 시 메인(랜딩) 페이지(`/`)로 이동하도록 수정  
- 모바일 화면에서 검색 아이콘 클릭 시 검색창 활성화 기능 추가 


## 스크린샷(선택)
https://github.com/user-attachments/assets/ff228424-9714-491e-9b3a-61a9f278101b
(검색 결과가 안 나오는 건 백엔드에서 지금 작업중이라 서버 잠깐 막은듯)


## 💬리뷰 요구사항 / 질문(선택)
초간단한 기능이라 문제없지 않을..까?요?ㅎ 

만약 로컬에서 테스트하신다면
- 로고 클릭 시 `/` 페이지로 정상 이동하는지 확인  
- 모바일 환경에서 검색 아이콘 클릭 시 검색창이 활성화되는지 확인 부탁드립니다

## 전달사항
- searchbar 담당자 소빈님: P3 검색 결과 화면으로 이동 후 사용자가 다른 페이지로 이동하면 searchbar에 검색어가 없어지도록 하는 기능이 있음 좋을 것 같습니다 
