### PR TITLE
style: filterSelect 크기 고정

### DIFF
--- a/src/components/Common/FilterSelect.tsx
+++ b/src/components/Common/FilterSelect.tsx
@@ -42,6 +42,7 @@ export default FilterSelect;
 const Container = styled.div`
     position: relative;
     display : inline-flex;
+    width : 8.5rem;
 `;
 
 const StyledButton = styled.button`
@@ -66,7 +67,6 @@ const StyledButton = styled.button`
 `;
 
 const DropdownIcon = styled.img`
-    margin-left : 1.389vw;
     width: 0.875rem;
     height: 0.875rem;
     background-size: contain;


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가 (Feat)
- [ ] 버그 / 에러 수정 (Fix)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] 코드 구조 등 리팩토링 (Refactor)
- [x] 스타일 추가 및 수정 (Style)
- [ ] 문서 관련 (Docs)
- [ ] 기능 삭제 (Delete)


## 📝작업 내용
filterSelect.tsx의 width가 기존 글자 수에 따라 달라졌는데, 정신없기도 하고 filter에 글자 수가 적은데 드롭박스 속 글자 수가 길면 너무 못생겨져서  고정 크기로 바꿨습니다


## 스크린샷(선택)

https://github.com/user-attachments/assets/357fa683-7432-45ed-b81b-97b007534c9e




## 💬리뷰 요구사항 / 질문(선택)
너무 길어서 못생겼나요 ??


## TO-DO(선택)
- [ ] _To Do를 작성해 주세요_
